### PR TITLE
Add nav bar to homepage

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Welcome to the BakkesMod Programming Wiki!
 description: Welcome to the BakkesMod Programming Wiki! Find helpful code to get started and an API reference
-geekdocNav: false
 geekdocAlign: center
 geekdocAnchor: false
 ---


### PR DESCRIPTION
I don't like having to click through to the tutorial in order to access the navigation bar. Can we put it on the homepage as well?