### PR TITLE
Update PersistentStorage.cpp to not require fmt.

### DIFF
--- a/static/files/PersistentStorage.cpp
+++ b/static/files/PersistentStorage.cpp
@@ -35,7 +35,7 @@ void PersistentStorage::WritePersistentStorage()
 	//LOG("PersistentStorage: Writing to file");
 	for (const auto& [cvar, cvar_cache_item] : cvar_cache_)
 	{
-		out << fmt::format("{} \"{}\" //{}\n", cvar, cvar_cache_item.value, cvar_cache_item.description);
+		out << cvar << " \"" << cvar_cache_item.value << "\" //" << cvar_cache_item.description << "\n";
 	}
 }
 


### PR DESCRIPTION
fmt isn't really utilized here and just adds a dependency. separately fmt isn't actually #include'd into this file to begin with.

I've verified this handles unicode characters.